### PR TITLE
add name as arra

### DIFF
--- a/article-authoring-schema.json
+++ b/article-authoring-schema.json
@@ -11,8 +11,23 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
+            "type": "array",
             "description": "The full name of an author."
+             "items": {
+        "type": "object",
+        "properties": {
+          "given name": {
+            "type": "string",
+            "description": "The given name of an author."
+          },
+          "surname": {
+            "type": "string",
+            "description": "The surname of an author."
+          },
+          "middle name": {
+            "type": "string",
+            "description": "The middle name(s) of an author."
+          }
           },
           "affiliation": {
             "oneOf": [


### PR DESCRIPTION
 I am not sure it works, and I wonder how to make it compatible with instance where the whole name is given.

see ```<string-name>. It is at the publisher’s discretion whether to use <name> or <string-name> to capture an author’s name, though note that <string-name> is not allowed in <contrib> in JATS Blue. However, if a name is not easily broken down into a surname and given names (e.g., names such as “Prince” or “Prince Charles”), then if the publisher is using JATS Green, they should contain the entire string of the name in <string-name> to facilitate retrieval, per the JATS tag library guidelines.
``` in https://jats4r.org/authors-and-affiliations